### PR TITLE
Fix the lifecycle of BoostTimer: H_Timer can outlive its parent

### DIFF
--- a/lcb-boost-plugin.cpp
+++ b/lcb-boost-plugin.cpp
@@ -332,6 +332,8 @@ public:
         H_Timer(BoostTimer *tm) : parent(tm) {}
         void operator() (const error_code& ec) {
             if (ec) { return; }
+            // This callback can be called even after the timer has been canceled.
+            if (parent->callback == NULL) { return; }
             parent->callback(-1, 0, parent->arg);
         }
     };


### PR DESCRIPTION
The H_Timer callback can outlive its parent BoostTimer under certain circumstances. Fixed the lifecycle of BoostTimer class, enabling shared_from_this to it.